### PR TITLE
Update composer to support CakePHP 3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["cakephp", "oauth", "oauth2", "oauth server", "oauth2 server"],
     "require": {
         "php": ">=7.3.0",
-        "cakephp/cakephp": "3.8.*",
+        "cakephp/cakephp": "3.9.*",
         "league/oauth2-server": "dev-authorization-server ",
         "cakephp/migrations": "~2.0"
     },


### PR DESCRIPTION
In order to update CakePHP 3.9 we need oauth-server plugin to support it.